### PR TITLE
[SCOUT-106] include count & player team in orders response

### DIFF
--- a/src/modules/orders/dto/order.dto.ts
+++ b/src/modules/orders/dto/order.dto.ts
@@ -2,9 +2,16 @@ import { PickType } from '@nestjs/swagger';
 import { Expose, plainToInstance, Transform } from 'class-transformer';
 
 import { MatchBasicDataDto } from '../../matches/dto/match.dto';
-import { PlayerBasicDataWithoutTeamsDto } from '../../players/dto/player.dto';
+import {
+  PlayerBasicDataDto,
+  PlayerBasicDataWithoutTeamsDto,
+} from '../../players/dto/player.dto';
 import { UserBasicDataDto } from '../../users/dto/user.dto';
 import { OrderStatusEnum } from '../types';
+
+class OrderCount {
+  reports: number;
+}
 
 export class OrderDto {
   @Expose()
@@ -45,12 +52,12 @@ export class OrderDto {
   scout?: UserBasicDataDto;
 
   @Transform(({ value }) =>
-    plainToInstance(PlayerBasicDataWithoutTeamsDto, value, {
+    plainToInstance(PlayerBasicDataDto, value, {
       excludeExtraneousValues: true,
     }),
   )
   @Expose()
-  player?: PlayerBasicDataWithoutTeamsDto;
+  player?: PlayerBasicDataDto;
 
   @Transform(({ value }) =>
     plainToInstance(MatchBasicDataDto, value, {
@@ -59,6 +66,9 @@ export class OrderDto {
   )
   @Expose()
   match?: MatchBasicDataDto;
+
+  @Expose()
+  _count: OrderCount;
 }
 
 class PlayerSuperBasicInfoDto extends PickType(PlayerBasicDataWithoutTeamsDto, [

--- a/src/modules/orders/orders.service.ts
+++ b/src/modules/orders/orders.service.ts
@@ -20,8 +20,15 @@ import { OrdersPaginationOptionsDto } from './dto/orders-pagination-options.dto'
 const include: Prisma.OrderInclude = {
   author: true,
   scout: true,
-  player: { include: { primaryPosition: true, country: true } },
+  player: {
+    include: {
+      primaryPosition: true,
+      country: true,
+      teams: { where: { endDate: null }, include: { team: true } },
+    },
+  },
   match: { include: { homeTeam: true, awayTeam: true, competition: true } },
+  _count: { select: { reports: true } },
 };
 
 const { author, scout, ...listInclude } = include;


### PR DESCRIPTION
[SCOUT-106](https://playmakerpro.atlassian.net/browse/SCOUT-106)

### Task Description

Include `reportsCount` & player team in `GET /` endpoint response

### Additional Notes (optional)

<!-- Provide any additional notes: related PRs, screenshots, et al.). -->
