### PR TITLE
fix: list handle null where

### DIFF
--- a/src/modules/insider-notes/insider-notes.service.ts
+++ b/src/modules/insider-notes/insider-notes.service.ts
@@ -254,7 +254,10 @@ export class InsiderNotesService {
   }
 
   getList(accessFilters?: Prisma.InsiderNoteWhereInput) {
-    return this.prisma.insiderNote.findMany({ where: accessFilters, include });
+    return this.prisma.insiderNote.findMany({
+      where: accessFilters || undefined,
+      include,
+    });
   }
 
   async findOne(


### PR DESCRIPTION
### Task Description
[SCOUT-227](https://playmakerpro.atlassian.net/browse/SCOUT-227?atlOrigin=eyJpIjoiYjE4NmRmMTc2NDU0NDZiMWE3OWUwOTY1MWRiNjMxZTEiLCJwIjoiaiJ9)

- fixed insider notes list

when no params are used `where` is null and it throws error
