### PR TITLE
Fix/scout 242 reports notes delete

### DIFF
--- a/prisma/migrations/20221031155709_referentials_actions/migration.sql
+++ b/prisma/migrations/20221031155709_referentials_actions/migration.sql
@@ -1,0 +1,53 @@
+-- DropForeignKey
+ALTER TABLE "LikeNote" DROP CONSTRAINT "LikeNote_noteId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "LikeReport" DROP CONSTRAINT "LikeReport_reportId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "NoteMeta" DROP CONSTRAINT "NoteMeta_noteId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "ReportMeta" DROP CONSTRAINT "ReportMeta_reportId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "ReportSkillAssessment" DROP CONSTRAINT "ReportSkillAssessment_reportId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "organization_note_access_control_list" DROP CONSTRAINT "organization_note_access_control_list_noteId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "organization_report_access_control_list" DROP CONSTRAINT "organization_report_access_control_list_reportId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "user_note_access_control_list" DROP CONSTRAINT "user_note_access_control_list_noteId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "user_report_access_control_list" DROP CONSTRAINT "user_report_access_control_list_reportId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "NoteMeta" ADD CONSTRAINT "NoteMeta_noteId_fkey" FOREIGN KEY ("noteId") REFERENCES "Note"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ReportSkillAssessment" ADD CONSTRAINT "ReportSkillAssessment_reportId_fkey" FOREIGN KEY ("reportId") REFERENCES "Report"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ReportMeta" ADD CONSTRAINT "ReportMeta_reportId_fkey" FOREIGN KEY ("reportId") REFERENCES "Report"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_report_access_control_list" ADD CONSTRAINT "user_report_access_control_list_reportId_fkey" FOREIGN KEY ("reportId") REFERENCES "Report"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "organization_report_access_control_list" ADD CONSTRAINT "organization_report_access_control_list_reportId_fkey" FOREIGN KEY ("reportId") REFERENCES "Report"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_note_access_control_list" ADD CONSTRAINT "user_note_access_control_list_noteId_fkey" FOREIGN KEY ("noteId") REFERENCES "Note"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "organization_note_access_control_list" ADD CONSTRAINT "organization_note_access_control_list_noteId_fkey" FOREIGN KEY ("noteId") REFERENCES "Note"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "LikeReport" ADD CONSTRAINT "LikeReport_reportId_fkey" FOREIGN KEY ("reportId") REFERENCES "Report"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "LikeNote" ADD CONSTRAINT "LikeNote_noteId_fkey" FOREIGN KEY ("noteId") REFERENCES "Note"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -466,7 +466,7 @@ model NoteMeta {
   updatedAt DateTime @updatedAt
 
   // Relation fields
-  note               Note              @relation(fields: [noteId], references: [id])
+  note               Note              @relation(fields: [noteId], references: [id], onDelete: Cascade)
   noteId             String            @unique
   position           PlayerPosition?   @relation(fields: [positionId], references: [id])
   positionId         String?
@@ -583,7 +583,7 @@ model ReportSkillAssessment {
   // Relation fields
   template   ReportSkillAssessmentTemplate @relation(fields: [templateId], references: [id])
   templateId String
-  report     Report                        @relation(fields: [reportId], references: [id])
+  report     Report                        @relation(fields: [reportId], references: [id], onDelete: Cascade)
   reportId   String
 }
 
@@ -635,7 +635,7 @@ model ReportMeta {
   updatedAt DateTime @updatedAt
 
   // Relation fields
-  report             Report            @relation(fields: [reportId], references: [id])
+  report             Report            @relation(fields: [reportId], references: [id], onDelete: Cascade)
   reportId           String            @unique
   position           PlayerPosition?   @relation(fields: [positionId], references: [id])
   positionId         String?
@@ -960,7 +960,7 @@ model UserReportAccessControlEntry {
   // Relation Fields
   user     User   @relation(fields: [userId], references: [id])
   userId   String
-  report   Report @relation(fields: [reportId], references: [id])
+  report   Report @relation(fields: [reportId], references: [id], onDelete: Cascade)
   reportId String
 
   @@unique([userId, reportId])
@@ -976,7 +976,7 @@ model OrganizationReportAccessControlEntry {
   // Relation Fields
   organization   Organization @relation(fields: [organizationId], references: [id])
   organizationId String
-  report         Report       @relation(fields: [reportId], references: [id])
+  report         Report       @relation(fields: [reportId], references: [id], onDelete: Cascade)
   reportId       String
 
   @@unique([organizationId, reportId])
@@ -992,7 +992,7 @@ model UserNoteAccessControlEntry {
   // Relation Fields
   user   User   @relation(fields: [userId], references: [id])
   userId String
-  note   Note   @relation(fields: [noteId], references: [id])
+  note   Note   @relation(fields: [noteId], references: [id], onDelete: Cascade)
   noteId String
 
   @@unique([userId, noteId])
@@ -1008,7 +1008,7 @@ model OrganizationNoteAccessControlEntry {
   // Relation Fields
   organization   Organization @relation(fields: [organizationId], references: [id])
   organizationId String
-  note           Note         @relation(fields: [noteId], references: [id])
+  note           Note         @relation(fields: [noteId], references: [id], onDelete: Cascade)
   noteId         String
 
   @@unique([organizationId, noteId])
@@ -1067,7 +1067,7 @@ model LikeReport {
   updatedAt DateTime @updatedAt
 
   // Relation fields
-  report   Report @relation(fields: [reportId], references: [id])
+  report   Report @relation(fields: [reportId], references: [id], onDelete: Cascade)
   reportId String
   user     User   @relation(fields: [userId], references: [id])
   userId   String
@@ -1081,7 +1081,7 @@ model LikeNote {
   updatedAt DateTime @updatedAt
 
   // Relation fields
-  note   Note   @relation(fields: [noteId], references: [id])
+  note   Note   @relation(fields: [noteId], references: [id], onDelete: Cascade)
   noteId String
   user   User   @relation(fields: [userId], references: [id])
   userId String

--- a/src/modules/notes/notes.service.ts
+++ b/src/modules/notes/notes.service.ts
@@ -5,6 +5,7 @@ import Redis from 'ioredis';
 
 import { REDIS_TTL } from '../../utils/constants';
 import { parseCsv, validateInstances } from '../../utils/csv-helpers';
+import { deleteIfExists } from '../../utils/deleteIfExists';
 import {
   calculatePercentageRating,
   calculateSkip,
@@ -450,12 +451,19 @@ export class NotesService {
 
   async remove(id: string) {
     await Promise.all([
-      this.prisma.noteMeta.delete({ where: { noteId: id } }),
+      deleteIfExists(() =>
+        this.prisma.noteMeta.delete({ where: { noteId: id } }),
+      ),
       this.prisma.userNoteAccessControlEntry.deleteMany({
         where: { noteId: id },
       }),
       this.prisma.organizationNoteAccessControlEntry.deleteMany({
         where: { noteId: id },
+      }),
+      this.prisma.likeNote.deleteMany({
+        where: {
+          noteId: id,
+        },
       }),
     ]);
     return this.prisma.note.delete({ where: { id }, include });

--- a/src/modules/notes/notes.service.ts
+++ b/src/modules/notes/notes.service.ts
@@ -450,22 +450,6 @@ export class NotesService {
   }
 
   async remove(id: string) {
-    await Promise.all([
-      deleteIfExists(() =>
-        this.prisma.noteMeta.delete({ where: { noteId: id } }),
-      ),
-      this.prisma.userNoteAccessControlEntry.deleteMany({
-        where: { noteId: id },
-      }),
-      this.prisma.organizationNoteAccessControlEntry.deleteMany({
-        where: { noteId: id },
-      }),
-      this.prisma.likeNote.deleteMany({
-        where: {
-          noteId: id,
-        },
-      }),
-    ]);
     return this.prisma.note.delete({ where: { id }, include });
   }
 }

--- a/src/modules/reports/reports.service.ts
+++ b/src/modules/reports/reports.service.ts
@@ -5,6 +5,7 @@ import Redis from 'ioredis';
 
 import { REDIS_TTL } from '../../utils/constants';
 import { parseCsv, validateInstances } from '../../utils/csv-helpers';
+import { deleteIfExists } from '../../utils/deleteIfExists';
 import {
   calculateAvg,
   calculatePercentageRating,
@@ -525,13 +526,17 @@ export class ReportsService {
 
   async remove(id: string) {
     await Promise.all([
-      this.prisma.reportMeta.delete({ where: { reportId: id } }),
+      deleteIfExists(() =>
+        this.prisma.reportMeta.delete({ where: { reportId: id } }),
+      ),
       this.prisma.userReportAccessControlEntry.deleteMany({
         where: { reportId: id },
       }),
       this.prisma.organizationReportAccessControlEntry.deleteMany({
         where: { reportId: id },
       }),
+      this.prisma.likeReport.deleteMany({ where: { reportId: id } }),
+      this.prisma.reportSkillAssessment.deleteMany({ where: { reportId: id } }),
     ]);
 
     return this.prisma.report.delete({ where: { id }, include });

--- a/src/modules/reports/reports.service.ts
+++ b/src/modules/reports/reports.service.ts
@@ -525,20 +525,6 @@ export class ReportsService {
   }
 
   async remove(id: string) {
-    await Promise.all([
-      deleteIfExists(() =>
-        this.prisma.reportMeta.delete({ where: { reportId: id } }),
-      ),
-      this.prisma.userReportAccessControlEntry.deleteMany({
-        where: { reportId: id },
-      }),
-      this.prisma.organizationReportAccessControlEntry.deleteMany({
-        where: { reportId: id },
-      }),
-      this.prisma.likeReport.deleteMany({ where: { reportId: id } }),
-      this.prisma.reportSkillAssessment.deleteMany({ where: { reportId: id } }),
-    ]);
-
     return this.prisma.report.delete({ where: { id }, include });
   }
 }

--- a/src/utils/deleteIfExists.ts
+++ b/src/utils/deleteIfExists.ts
@@ -1,0 +1,11 @@
+import { Prisma } from '@prisma/client';
+
+export const deleteIfExists = async (fn: () => Promise<any>) => {
+  try {
+    await fn();
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      if (error.meta?.cause !== 'Record to delete does not exist.') throw error;
+    }
+  }
+};


### PR DESCRIPTION
### Task Description
[SCOUT-242](https://playmakerpro.atlassian.net/browse/SCOUT-242?atlOrigin=eyJpIjoiZmVmMWQzM2EwZTA2NDgxNjliNGU2MjA0NmI1NmYzYzgiLCJwIjoiaiJ9)

- fixed deleting when is liked
- added helper to handle deleting single record without breaking on error when record doesn't exist (no internal way to do it as far as I know😨)

`Foreign key constraint failed on the field: ReportSkillAssessment_reportId_fkey (index)`
- fixed above error by deleting `reportSkillAssessment's` as well (right way??)

