### PR TITLE
Fix/docs-auth

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Attach",
+      "port": 9229,
+      "request": "attach",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "type": "node"
+    }
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,9 +8,7 @@
       "name": "Attach",
       "port": 9229,
       "request": "attach",
-      "skipFiles": [
-        "<node_internals>/**"
-      ],
+      "skipFiles": ["<node_internals>/**"],
       "type": "node"
     }
   ]

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "node dist/main",
     "start:dev": "dotenv -e .env.development -- nest start --watch",
-    "start:debug": "dotenv -e .env.development nest start --debug --watch",
+    "start:debug": "dotenv -e .env.development -- nest start --debug --watch",
     "start:prod": "nest start",
     "migrate:postgres": "dotenv -e .env.development -- npx prisma migrate dev",
     "reset:postgres": "dotenv -e .env.development -- npx prisma migrate reset",

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,7 +37,18 @@ async function bootstrap() {
   const config = new DocumentBuilder()
     .setTitle('Scoutmaker Pro API v2')
     .setVersion('2.0')
-    .addCookieAuth('token')
+    .addApiKey(
+      {
+        type: 'apiKey',
+        name: 'x-auth-token',
+        in: 'header',
+      },
+      'auth-token',
+    )
+    .addServer(`http://localhost:${port}`)
+    .setDescription(
+      `<a href="https://insomnia.rest/run/?label=ScoutMaker%20API%202.0&uri=http%3A%2F%2Flocalhost%3A${port}%2Fapi-docs-json" target="_blank"><img src="https://insomnia.rest/images/run.svg" alt="Run in Insomnia"></a>`,
+    )
     .build();
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api-docs', app, document);

--- a/src/modules/agencies/agencies.controller.ts
+++ b/src/modules/agencies/agencies.controller.ts
@@ -10,7 +10,7 @@ import {
   Query,
   UseGuards,
 } from '@nestjs/common';
-import { ApiCookieAuth, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { ApiSecurity, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { I18nLang, I18nService } from 'nestjs-i18n';
 
 import { ApiResponse } from '../../common/api-response/api-response.decorator';
@@ -30,7 +30,7 @@ import { UpdateAgencyDto } from './dto/update-agency.dto';
 @Controller('agencies')
 @ApiTags('agencies')
 @UseGuards(AuthGuard)
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 export class AgenciesController {
   constructor(
     private readonly agenciesService: AgenciesService,

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -10,7 +10,7 @@ import {
   Res,
   UseGuards,
 } from '@nestjs/common';
-import { ApiCookieAuth, ApiTags } from '@nestjs/swagger';
+import { ApiSecurity, ApiTags } from '@nestjs/swagger';
 import { add } from 'date-fns';
 import { CookieOptions, Response } from 'express';
 import { I18nLang, I18nService } from 'nestjs-i18n';
@@ -93,7 +93,7 @@ export class AuthController {
   @ApiResponse(UserDto, { type: 'read' })
   @Serialize(UserDto)
   @UseGuards(AuthGuard)
-  @ApiCookieAuth()
+  @ApiSecurity('auth-token')
   async getAccount(
     @I18nLang() lang: string,
     @CurrentUser() user: CurrentUserDto,
@@ -109,7 +109,7 @@ export class AuthController {
   @ApiResponse(UserDto, { type: 'update' })
   @Serialize(UserDto)
   @UseGuards(AuthGuard)
-  @ApiCookieAuth()
+  @ApiSecurity('auth-token')
   async updateAccount(
     @I18nLang() lang: string,
     @CurrentUser() user: CurrentUserDto,
@@ -126,7 +126,7 @@ export class AuthController {
   @ApiResponse(UserDto, { type: 'update' })
   @Serialize(UserDto, 'user')
   @UseGuards(AuthGuard)
-  @ApiCookieAuth()
+  @ApiSecurity('auth-token')
   async updatePassword(
     @I18nLang() lang: string,
     @CurrentUser() user: CurrentUserDto,

--- a/src/modules/clubs/clubs.controller.ts
+++ b/src/modules/clubs/clubs.controller.ts
@@ -15,7 +15,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import {
   ApiBody,
   ApiConsumes,
-  ApiCookieAuth,
+  ApiSecurity,
   ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
@@ -40,7 +40,7 @@ import { UpdateClubDto } from './dto/update-club.dto';
 @Controller('clubs')
 @ApiTags('clubs')
 @UseGuards(AuthGuard)
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 export class ClubsController {
   constructor(
     private readonly clubsService: ClubsService,

--- a/src/modules/competition-age-categories/competition-age-categories.controller.ts
+++ b/src/modules/competition-age-categories/competition-age-categories.controller.ts
@@ -15,7 +15,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import {
   ApiBody,
   ApiConsumes,
-  ApiCookieAuth,
+  ApiSecurity,
   ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
@@ -38,7 +38,7 @@ import { UpdateCompetitionAgeCategoryDto } from './dto/update-competition-age-ca
 @Controller('competition-age-categories')
 @ApiTags('competition age categories')
 @UseGuards(AuthGuard, new RoleGuard(['ADMIN']))
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 export class CompetitionAgeCategoriesController {
   constructor(
     private readonly ageCategoriesService: CompetitionAgeCategoriesService,

--- a/src/modules/competition-groups/competition-groups.controller.ts
+++ b/src/modules/competition-groups/competition-groups.controller.ts
@@ -16,7 +16,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import {
   ApiBody,
   ApiConsumes,
-  ApiCookieAuth,
+  ApiSecurity,
   ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
@@ -42,7 +42,7 @@ import { UpdateCompetitionGroupDto } from './dto/update-competition-group.dto';
 @Controller('competition-groups')
 @ApiTags('competition groups')
 @UseGuards(AuthGuard)
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 export class CompetitionGroupsController {
   constructor(
     private readonly groupsService: CompetitionGroupsService,

--- a/src/modules/competition-junior-levels/competition-junior-levels.controller.ts
+++ b/src/modules/competition-junior-levels/competition-junior-levels.controller.ts
@@ -9,7 +9,7 @@ import {
   Query,
   UseGuards,
 } from '@nestjs/common';
-import { ApiCookieAuth, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { ApiSecurity, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { I18nLang, I18nService } from 'nestjs-i18n';
 
 import { ApiPaginatedResponse } from '../../common/api-response/api-paginated-response.decorator';
@@ -29,7 +29,7 @@ import { UpdateCompetitionJuniorLevelDto } from './dto/update-competition-junior
 @Controller('competition-junior-levels')
 @ApiTags('competition junior levels')
 @UseGuards(AuthGuard, new RoleGuard(['ADMIN']))
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 export class CompetitionJuniorLevelsController {
   constructor(
     private readonly juniorLevelsService: CompetitionJuniorLevelsService,

--- a/src/modules/competition-participations/competition-participations.controller.ts
+++ b/src/modules/competition-participations/competition-participations.controller.ts
@@ -15,7 +15,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import {
   ApiBody,
   ApiConsumes,
-  ApiCookieAuth,
+  ApiSecurity,
   ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
@@ -39,7 +39,7 @@ import { UpdateCompetitionParticipationDto } from './dto/update-competition-part
 @Controller('competition-participations')
 @ApiTags('competition participations')
 @UseGuards(AuthGuard)
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 export class CompetitionParticipationsController {
   constructor(
     private readonly participationsService: CompetitionParticipationsService,

--- a/src/modules/competition-types/competition-types.controller.ts
+++ b/src/modules/competition-types/competition-types.controller.ts
@@ -15,7 +15,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import {
   ApiBody,
   ApiConsumes,
-  ApiCookieAuth,
+  ApiSecurity,
   ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
@@ -38,7 +38,7 @@ import { UpdateCompetitionTypeDto } from './dto/update-competition-type.dto';
 @Controller('competition-types')
 @ApiTags('competition types')
 @UseGuards(AuthGuard, new RoleGuard(['ADMIN']))
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 export class CompetitionTypesController {
   constructor(
     private readonly typesService: CompetitionTypesService,

--- a/src/modules/competitions/competitions.controller.ts
+++ b/src/modules/competitions/competitions.controller.ts
@@ -15,7 +15,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import {
   ApiBody,
   ApiConsumes,
-  ApiCookieAuth,
+  ApiSecurity,
   ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
@@ -38,7 +38,7 @@ import { UpdateCompetitionDto } from './dto/update-competition.dto';
 @Controller('competitions')
 @ApiTags('competitions')
 @UseGuards(AuthGuard)
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 export class CompetitionsController {
   constructor(
     private readonly competitionsService: CompetitionsService,

--- a/src/modules/countries/countries.controller.ts
+++ b/src/modules/countries/countries.controller.ts
@@ -15,7 +15,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import {
   ApiBody,
   ApiConsumes,
-  ApiCookieAuth,
+  ApiSecurity,
   ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
@@ -38,7 +38,7 @@ import { UpdateCountryDto } from './dto/update-country.dto';
 @Controller('countries')
 @ApiTags('countries')
 @UseGuards(AuthGuard)
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 export class CountriesController {
   constructor(
     private readonly countriesService: CountriesService,

--- a/src/modules/follow-agencies/follow-agencies.controller.ts
+++ b/src/modules/follow-agencies/follow-agencies.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Delete, Param, Post, UseGuards } from '@nestjs/common';
-import { ApiCookieAuth, ApiTags } from '@nestjs/swagger';
+import { ApiSecurity, ApiTags } from '@nestjs/swagger';
 import { I18nLang, I18nService } from 'nestjs-i18n';
 
 import { ApiResponse } from '../../common/api-response/api-response.decorator';
@@ -15,7 +15,7 @@ import { FollowAgenciesService } from './follow-agencies.service';
 @Controller('follow-agencies')
 @ApiTags('follow agencies')
 @UseGuards(AuthGuard)
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 @Serialize(FollowAgencyDto)
 export class FollowAgenciesController {
   constructor(

--- a/src/modules/follow-players/follow-players.controller.ts
+++ b/src/modules/follow-players/follow-players.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Delete, Param, Post, UseGuards } from '@nestjs/common';
-import { ApiCookieAuth, ApiTags } from '@nestjs/swagger';
+import { ApiSecurity, ApiTags } from '@nestjs/swagger';
 import { I18nLang, I18nService } from 'nestjs-i18n';
 
 import { ApiResponse } from '../../common/api-response/api-response.decorator';
@@ -15,7 +15,7 @@ import { FollowPlayersService } from './follow-players.service';
 @Controller('follow-players')
 @ApiTags('follow players')
 @UseGuards(AuthGuard)
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 @Serialize(FollowPlayerDto)
 export class FollowPlayersController {
   constructor(

--- a/src/modules/follow-scouts/follow-scouts.controller.ts
+++ b/src/modules/follow-scouts/follow-scouts.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Delete, Param, Post, UseGuards } from '@nestjs/common';
-import { ApiCookieAuth, ApiTags } from '@nestjs/swagger';
+import { ApiSecurity, ApiTags } from '@nestjs/swagger';
 import { I18nLang, I18nService } from 'nestjs-i18n';
 
 import { ApiResponse } from '../../common/api-response/api-response.decorator';
@@ -15,7 +15,7 @@ import { FollowScoutsService } from './follow-scouts.service';
 @Controller('follow-scouts')
 @ApiTags('follow scouts')
 @UseGuards(AuthGuard)
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 @Serialize(FollowScoutDto)
 export class FollowScoutsController {
   constructor(

--- a/src/modules/follow-teams/follow-teams.controller.ts
+++ b/src/modules/follow-teams/follow-teams.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Delete, Param, Post, UseGuards } from '@nestjs/common';
-import { ApiCookieAuth, ApiTags } from '@nestjs/swagger';
+import { ApiSecurity, ApiTags } from '@nestjs/swagger';
 import { I18nLang, I18nService } from 'nestjs-i18n';
 
 import { ApiResponse } from '../../common/api-response/api-response.decorator';
@@ -15,7 +15,7 @@ import { FollowTeamsService } from './follow-teams.service';
 @Controller('follow-teams')
 @ApiTags('follow teams')
 @UseGuards(AuthGuard)
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 @Serialize(FollowTeamDto)
 export class FollowTeamsController {
   constructor(

--- a/src/modules/insider-notes/insider-notes.controller.ts
+++ b/src/modules/insider-notes/insider-notes.controller.ts
@@ -15,7 +15,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import {
   ApiBody,
   ApiConsumes,
-  ApiCookieAuth,
+  ApiSecurity,
   ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
@@ -49,7 +49,7 @@ import { InsiderNotesService } from './insider-notes.service';
 @Controller('insider-notes')
 @ApiTags('insider notes')
 @UseGuards(AuthGuard)
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 export class InsiderNotesController {
   constructor(
     private readonly insiderNotesService: InsiderNotesService,

--- a/src/modules/like-insider-notes/like-insider-notes.controller.ts
+++ b/src/modules/like-insider-notes/like-insider-notes.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Delete, Param, Post, UseGuards } from '@nestjs/common';
-import { ApiCookieAuth, ApiTags } from '@nestjs/swagger';
+import { ApiSecurity, ApiTags } from '@nestjs/swagger';
 import { I18nLang, I18nService } from 'nestjs-i18n';
 
 import { ApiResponse } from '../../common/api-response/api-response.decorator';
@@ -15,7 +15,7 @@ import { LikeInsiderNotesService } from './like-insider-notes.service';
 @Controller('like-insider-notes')
 @ApiTags('like insider notes')
 @UseGuards(AuthGuard)
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 @Serialize(LikeInsiderNoteDto)
 export class InsiderNotesLikesController {
   constructor(

--- a/src/modules/like-notes/like-notes.controller.ts
+++ b/src/modules/like-notes/like-notes.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Delete, Param, Post, UseGuards } from '@nestjs/common';
-import { ApiCookieAuth, ApiTags } from '@nestjs/swagger';
+import { ApiSecurity, ApiTags } from '@nestjs/swagger';
 import { I18nLang, I18nService } from 'nestjs-i18n';
 
 import { ApiResponse } from '../../common/api-response/api-response.decorator';
@@ -15,7 +15,7 @@ import { LikeNotesService } from './like-notes.service';
 @Controller('like-notes')
 @ApiTags('like notes')
 @UseGuards(AuthGuard)
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 @Serialize(LikeNoteDto)
 export class LikeNotesController {
   constructor(

--- a/src/modules/like-players/like-players.controller.ts
+++ b/src/modules/like-players/like-players.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Delete, Param, Post, UseGuards } from '@nestjs/common';
-import { ApiCookieAuth, ApiTags } from '@nestjs/swagger';
+import { ApiSecurity, ApiTags } from '@nestjs/swagger';
 import { I18nLang, I18nService } from 'nestjs-i18n';
 
 import { ApiResponse } from '../../common/api-response/api-response.decorator';
@@ -15,7 +15,7 @@ import { LikePlayersService } from './like-players.service';
 @Controller('like-players')
 @ApiTags('like players')
 @UseGuards(AuthGuard)
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 @Serialize(LikePlayerDto)
 export class LikePlayersController {
   constructor(

--- a/src/modules/like-reports/like-reports.controller.ts
+++ b/src/modules/like-reports/like-reports.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Delete, Param, Post, UseGuards } from '@nestjs/common';
-import { ApiCookieAuth, ApiTags } from '@nestjs/swagger';
+import { ApiSecurity, ApiTags } from '@nestjs/swagger';
 import { I18nLang, I18nService } from 'nestjs-i18n';
 
 import { ApiResponse } from '../../common/api-response/api-response.decorator';
@@ -15,7 +15,7 @@ import { LikeReportsService } from './like-reports.service';
 @Controller('like-reports')
 @ApiTags('like reports')
 @UseGuards(AuthGuard)
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 @Serialize(LikeReportDto)
 export class LikeReportsController {
   constructor(

--- a/src/modules/like-teams/like-teams.controller.ts
+++ b/src/modules/like-teams/like-teams.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Delete, Param, Post, UseGuards } from '@nestjs/common';
-import { ApiCookieAuth, ApiTags } from '@nestjs/swagger';
+import { ApiSecurity, ApiTags } from '@nestjs/swagger';
 import { I18nLang, I18nService } from 'nestjs-i18n';
 
 import { ApiResponse } from '../../common/api-response/api-response.decorator';
@@ -15,7 +15,7 @@ import { LikeTeamsService } from './like-teams.service';
 @Controller('like-teams')
 @ApiTags('like teams')
 @UseGuards(AuthGuard)
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 @Serialize(LikeTeamDto)
 export class LikeTeamsController {
   constructor(

--- a/src/modules/match-attendances/match-attendances.controller.ts
+++ b/src/modules/match-attendances/match-attendances.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Param, Patch, Post, UseGuards } from '@nestjs/common';
-import { ApiCookieAuth, ApiTags } from '@nestjs/swagger';
+import { ApiSecurity, ApiTags } from '@nestjs/swagger';
 import { I18nLang, I18nService } from 'nestjs-i18n';
 
 import { ApiResponse } from '../../common/api-response/api-response.decorator';
@@ -15,7 +15,7 @@ import { MatchAttendancesService } from './match-attendances.service';
 @Controller('match-attendances')
 @ApiTags('match attendances')
 @UseGuards(AuthGuard)
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 @Serialize(MatchAttendanceDto)
 export class MatchAttendancesController {
   constructor(

--- a/src/modules/matches/matches.controller.ts
+++ b/src/modules/matches/matches.controller.ts
@@ -15,7 +15,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import {
   ApiBody,
   ApiConsumes,
-  ApiCookieAuth,
+  ApiSecurity,
   ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
@@ -42,7 +42,7 @@ import { MatchesService } from './matches.service';
 @Controller('matches')
 @ApiTags('matches')
 @UseGuards(AuthGuard)
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 export class MatchesController {
   constructor(
     private readonly matchesService: MatchesService,

--- a/src/modules/notes/notes.controller.ts
+++ b/src/modules/notes/notes.controller.ts
@@ -15,7 +15,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import {
   ApiBody,
   ApiConsumes,
-  ApiCookieAuth,
+  ApiSecurity,
   ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
@@ -50,7 +50,7 @@ import { NotesService } from './notes.service';
 @Controller('notes')
 @ApiTags('notes')
 @UseGuards(AuthGuard)
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 export class NotesController {
   constructor(
     private readonly notesService: NotesService,

--- a/src/modules/orders/orders.controller.ts
+++ b/src/modules/orders/orders.controller.ts
@@ -9,7 +9,7 @@ import {
   Query,
   UseGuards,
 } from '@nestjs/common';
-import { ApiCookieAuth, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { ApiSecurity, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { I18nLang, I18nService } from 'nestjs-i18n';
 
 import { ApiPaginatedResponse } from '../../common/api-response/api-paginated-response.decorator';
@@ -33,7 +33,7 @@ import { OrdersService } from './orders.service';
   AuthGuard,
   new RoleGuard(['ADMIN', 'PLAYMAKER_SCOUT', 'PLAYMAKER_SCOUT_MANAGER']),
 )
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 export class OrdersController {
   constructor(
     private readonly ordersService: OrdersService,

--- a/src/modules/organization-insider-note-acl/organization-insider-note-acl.controller.ts
+++ b/src/modules/organization-insider-note-acl/organization-insider-note-acl.controller.ts
@@ -10,7 +10,7 @@ import {
   Query,
   UseGuards,
 } from '@nestjs/common';
-import { ApiCookieAuth, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { ApiSecurity, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { I18nLang, I18nService } from 'nestjs-i18n';
 
 import { ApiPaginatedResponse } from '../../common/api-response/api-paginated-response.decorator';
@@ -30,7 +30,7 @@ import { OrganizationInsiderNoteAclService } from './organization-insider-note-a
 @Controller('organization-insider-note-acl')
 @ApiTags('organization insider note ACL')
 @UseGuards(AuthGuard, new RoleGuard(['ADMIN']))
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 export class OrganizationInsiderNoteAclController {
   constructor(
     private readonly aclService: OrganizationInsiderNoteAclService,

--- a/src/modules/organization-note-acl/organization-note-acl.controller.ts
+++ b/src/modules/organization-note-acl/organization-note-acl.controller.ts
@@ -10,7 +10,7 @@ import {
   Query,
   UseGuards,
 } from '@nestjs/common';
-import { ApiCookieAuth, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { ApiSecurity, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { I18nLang, I18nService } from 'nestjs-i18n';
 
 import { ApiPaginatedResponse } from '../../common/api-response/api-paginated-response.decorator';
@@ -30,7 +30,7 @@ import { OrganizationNoteAclService } from './organization-note-acl.service';
 @Controller('organization-note-acl')
 @ApiTags('organization note ACL')
 @UseGuards(AuthGuard, new RoleGuard(['ADMIN']))
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 export class OrganizationNoteAclController {
   constructor(
     private readonly aclService: OrganizationNoteAclService,

--- a/src/modules/organization-player-acl/organization-player-acl.controller.ts
+++ b/src/modules/organization-player-acl/organization-player-acl.controller.ts
@@ -10,7 +10,7 @@ import {
   Query,
   UseGuards,
 } from '@nestjs/common';
-import { ApiCookieAuth, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { ApiSecurity, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { I18nLang, I18nService } from 'nestjs-i18n';
 
 import { ApiPaginatedResponse } from '../../common/api-response/api-paginated-response.decorator';
@@ -30,7 +30,7 @@ import { OrganizationPlayerAclService } from './organization-player-acl.service'
 @Controller('organization-player-acl')
 @ApiTags('organization player ACL')
 @UseGuards(AuthGuard, new RoleGuard(['ADMIN']))
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 export class OrganizationPlayerAclController {
   constructor(
     private readonly aclService: OrganizationPlayerAclService,

--- a/src/modules/organization-report-acl/organization-report-acl.controller.ts
+++ b/src/modules/organization-report-acl/organization-report-acl.controller.ts
@@ -10,7 +10,7 @@ import {
   Query,
   UseGuards,
 } from '@nestjs/common';
-import { ApiCookieAuth, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { ApiSecurity, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { I18nLang, I18nService } from 'nestjs-i18n';
 
 import { ApiPaginatedResponse } from '../../common/api-response/api-paginated-response.decorator';
@@ -30,7 +30,7 @@ import { OrganizationReportAclService } from './organization-report-acl.service'
 @Controller('organization-report-acl')
 @ApiTags('organization report ACL')
 @UseGuards(AuthGuard, new RoleGuard(['ADMIN']))
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 export class OrganizationReportAclController {
   constructor(
     private readonly aclService: OrganizationReportAclService,

--- a/src/modules/organization-subscriptions/organization-subscriptions.controller.ts
+++ b/src/modules/organization-subscriptions/organization-subscriptions.controller.ts
@@ -10,7 +10,7 @@ import {
   Query,
   UseGuards,
 } from '@nestjs/common';
-import { ApiCookieAuth, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { ApiSecurity, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { I18nLang, I18nService } from 'nestjs-i18n';
 
 import { ApiPaginatedResponse } from '../../common/api-response/api-paginated-response.decorator';
@@ -30,7 +30,7 @@ import { OrganizationSubscriptionsService } from './organization-subscriptions.s
 @Controller('organization-subscriptions')
 @ApiTags('organization subscriptions')
 @UseGuards(AuthGuard, new RoleGuard(['ADMIN']))
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 export class OrganizationSubscriptionsController {
   constructor(
     private readonly organizationSubscriptionsService: OrganizationSubscriptionsService,

--- a/src/modules/organizations/organizations.controller.ts
+++ b/src/modules/organizations/organizations.controller.ts
@@ -15,7 +15,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import {
   ApiBody,
   ApiConsumes,
-  ApiCookieAuth,
+  ApiSecurity,
   ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
@@ -39,7 +39,7 @@ import { OrganizationsService } from './organizations.service';
 @Controller('organizations')
 @ApiTags('organizations')
 @UseGuards(AuthGuard, new RoleGuard(['ADMIN']))
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 export class OrganizationsController {
   constructor(
     private readonly organizationsService: OrganizationsService,

--- a/src/modules/player-positions/player-positions.controller.ts
+++ b/src/modules/player-positions/player-positions.controller.ts
@@ -15,7 +15,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import {
   ApiBody,
   ApiConsumes,
-  ApiCookieAuth,
+  ApiSecurity,
   ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
@@ -38,7 +38,7 @@ import { PlayerPositionsService } from './player-positions.service';
 @Controller('player-positions')
 @ApiTags('player positions')
 @UseGuards(AuthGuard)
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 export class PlayerPositionsController {
   constructor(
     private readonly positionsService: PlayerPositionsService,

--- a/src/modules/player-stats/player-stats.controller.ts
+++ b/src/modules/player-stats/player-stats.controller.ts
@@ -10,7 +10,7 @@ import {
   Query,
   UseGuards,
 } from '@nestjs/common';
-import { ApiCookieAuth, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { ApiSecurity, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { I18nLang, I18nService } from 'nestjs-i18n';
 
 import { ApiPaginatedResponse } from '../../common/api-response/api-paginated-response.decorator';
@@ -31,7 +31,7 @@ import { PlayerStatsService } from './player-stats.service';
 @Controller('player-stats')
 @ApiTags('player stats')
 @UseGuards(AuthGuard)
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 export class PlayerStatsController {
   constructor(
     private readonly playerStatsService: PlayerStatsService,

--- a/src/modules/players/players.controller.ts
+++ b/src/modules/players/players.controller.ts
@@ -16,7 +16,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import {
   ApiBody,
   ApiConsumes,
-  ApiCookieAuth,
+  ApiSecurity,
   ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
@@ -47,7 +47,7 @@ import { PlayersService } from './players.service';
 @Controller('players')
 @ApiTags('players')
 @UseGuards(AuthGuard)
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 export class PlayersController {
   constructor(
     private readonly playersService: PlayersService,

--- a/src/modules/regions/regions.controller.ts
+++ b/src/modules/regions/regions.controller.ts
@@ -15,7 +15,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import {
   ApiBody,
   ApiConsumes,
-  ApiCookieAuth,
+  ApiSecurity,
   ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
@@ -38,7 +38,7 @@ import { RegionsService } from './regions.service';
 @Controller('regions')
 @ApiTags('regions')
 @UseGuards(AuthGuard)
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 export class RegionsController {
   constructor(
     private readonly regionsService: RegionsService,

--- a/src/modules/report-background-images/report-background-images.controller.ts
+++ b/src/modules/report-background-images/report-background-images.controller.ts
@@ -9,7 +9,7 @@ import {
   Query,
   UseGuards,
 } from '@nestjs/common';
-import { ApiCookieAuth, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { ApiSecurity, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { I18nLang, I18nService } from 'nestjs-i18n';
 
 import { ApiPaginatedResponse } from '../../common/api-response/api-paginated-response.decorator';
@@ -28,7 +28,7 @@ import { ReportBackgroundImagesService } from './report-background-images.servic
 @Controller('report-background-images')
 @ApiTags('report background images')
 @UseGuards(AuthGuard)
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 export class ReportBackgroundImagesController {
   constructor(
     private readonly reportBackgroundImagesService: ReportBackgroundImagesService,

--- a/src/modules/report-skill-assessment-categories/report-skill-assessment-categories.controller.ts
+++ b/src/modules/report-skill-assessment-categories/report-skill-assessment-categories.controller.ts
@@ -15,7 +15,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import {
   ApiBody,
   ApiConsumes,
-  ApiCookieAuth,
+  ApiSecurity,
   ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
@@ -40,7 +40,7 @@ import { ReportSkillAssessmentCategoriesService } from './report-skill-assessmen
 @Controller('report-skill-assessment-categories')
 @ApiTags('report skill assessment categories')
 @UseGuards(AuthGuard)
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 export class ReportSkillAssessmentCategoriesController {
   constructor(
     private readonly categoriesService: ReportSkillAssessmentCategoriesService,

--- a/src/modules/report-skill-assessment-templates/report-skill-assessment-templates.controller.ts
+++ b/src/modules/report-skill-assessment-templates/report-skill-assessment-templates.controller.ts
@@ -15,7 +15,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import {
   ApiBody,
   ApiConsumes,
-  ApiCookieAuth,
+  ApiSecurity,
   ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
@@ -40,7 +40,7 @@ import { ReportSkillAssessmentTemplatesService } from './report-skill-assessment
 @Controller('report-skill-assessment-templates')
 @ApiTags('report skill assessment templates')
 @UseGuards(AuthGuard)
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 export class ReportSkillAssessmentTemplatesController {
   constructor(
     private readonly templatesService: ReportSkillAssessmentTemplatesService,

--- a/src/modules/report-skill-assessments/report-skill-assessments.controller.ts
+++ b/src/modules/report-skill-assessments/report-skill-assessments.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Query, UseGuards } from '@nestjs/common';
-import { ApiCookieAuth, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { ApiSecurity, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { I18nLang, I18nService } from 'nestjs-i18n';
 
 import { ApiPaginatedResponse } from '../../common/api-response/api-paginated-response.decorator';
@@ -15,7 +15,7 @@ import { ReportSkillAssessmentsService } from './report-skill-assessments.servic
 @Controller('report-skill-assessments')
 @ApiTags('report skill assessments')
 @UseGuards(AuthGuard)
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 export class ReportSkillAssessmentsController {
   constructor(
     private readonly assessmentsService: ReportSkillAssessmentsService,

--- a/src/modules/report-templates/report-templates.controller.ts
+++ b/src/modules/report-templates/report-templates.controller.ts
@@ -15,7 +15,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import {
   ApiBody,
   ApiConsumes,
-  ApiCookieAuth,
+  ApiSecurity,
   ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
@@ -43,7 +43,7 @@ import { ReportTemplatesService } from './report-templates.service';
 @Controller('report-templates')
 @ApiTags('report templates')
 @UseGuards(AuthGuard)
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 export class ReportTemplatesController {
   constructor(
     private readonly reportTemplatesService: ReportTemplatesService,

--- a/src/modules/reports/reports.controller.ts
+++ b/src/modules/reports/reports.controller.ts
@@ -15,7 +15,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import {
   ApiBody,
   ApiConsumes,
-  ApiCookieAuth,
+  ApiSecurity,
   ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
@@ -50,7 +50,7 @@ import { ReportsService } from './reports.service';
 @Controller('reports')
 @ApiTags('reports')
 @UseGuards(AuthGuard)
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 export class ReportsController {
   constructor(
     private readonly reportsService: ReportsService,

--- a/src/modules/seasons/seasons.controller.ts
+++ b/src/modules/seasons/seasons.controller.ts
@@ -15,7 +15,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import {
   ApiBody,
   ApiConsumes,
-  ApiCookieAuth,
+  ApiSecurity,
   ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
@@ -39,7 +39,7 @@ import { SeasonsService } from './seasons.service';
 @Controller('seasons')
 @ApiTags('seasons')
 @UseGuards(AuthGuard)
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 export class SeasonsController {
   constructor(
     private readonly seasonsService: SeasonsService,

--- a/src/modules/team-affiliations/team-affiliations.controller.ts
+++ b/src/modules/team-affiliations/team-affiliations.controller.ts
@@ -15,7 +15,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import {
   ApiBody,
   ApiConsumes,
-  ApiCookieAuth,
+  ApiSecurity,
   ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
@@ -38,7 +38,7 @@ import { TeamAffiliationsService } from './team-affiliations.service';
 @Controller('team-affiliations')
 @ApiTags('team affiliations')
 @UseGuards(AuthGuard)
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 export class TeamAffiliationsController {
   constructor(
     private readonly teamAffiliationsService: TeamAffiliationsService,

--- a/src/modules/teams/teams.controller.ts
+++ b/src/modules/teams/teams.controller.ts
@@ -15,7 +15,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import {
   ApiBody,
   ApiConsumes,
-  ApiCookieAuth,
+  ApiSecurity,
   ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
@@ -40,7 +40,7 @@ import { TeamsService } from './teams.service';
 @Controller('teams')
 @ApiTags('teams')
 @UseGuards(AuthGuard)
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 export class TeamsController {
   constructor(
     private readonly teamsService: TeamsService,

--- a/src/modules/user-football-roles/user-football-roles.controller.ts
+++ b/src/modules/user-football-roles/user-football-roles.controller.ts
@@ -15,7 +15,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import {
   ApiBody,
   ApiConsumes,
-  ApiCookieAuth,
+  ApiSecurity,
   ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
@@ -38,7 +38,7 @@ import { UserFootballRolesService } from './user-football-roles.service';
 @Controller('user-football-roles')
 @ApiTags('user football roles')
 @UseGuards(AuthGuard)
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 export class UserFootballRolesController {
   constructor(
     private readonly rolesService: UserFootballRolesService,

--- a/src/modules/user-insider-note-acl/user-insider-note-acl.controller.ts
+++ b/src/modules/user-insider-note-acl/user-insider-note-acl.controller.ts
@@ -10,7 +10,7 @@ import {
   Query,
   UseGuards,
 } from '@nestjs/common';
-import { ApiCookieAuth, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { ApiSecurity, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { I18nLang, I18nService } from 'nestjs-i18n';
 
 import { ApiPaginatedResponse } from '../../common/api-response/api-paginated-response.decorator';
@@ -30,7 +30,7 @@ import { UserInsiderNoteAclService } from './user-insider-note-acl.service';
 @Controller('user-insider-note-acl')
 @ApiTags('user insider note ACL')
 @UseGuards(AuthGuard, new RoleGuard(['ADMIN']))
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 export class UserInsiderNoteAclController {
   constructor(
     private readonly aclService: UserInsiderNoteAclService,

--- a/src/modules/user-note-acl/user-note-acl.controller.ts
+++ b/src/modules/user-note-acl/user-note-acl.controller.ts
@@ -10,7 +10,7 @@ import {
   Query,
   UseGuards,
 } from '@nestjs/common';
-import { ApiCookieAuth, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { ApiSecurity, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { I18nLang, I18nService } from 'nestjs-i18n';
 
 import { ApiPaginatedResponse } from '../../common/api-response/api-paginated-response.decorator';
@@ -30,7 +30,7 @@ import { UserNoteAclService } from './user-note-acl.service';
 @Controller('user-note-acl')
 @ApiTags('user note ACL')
 @UseGuards(AuthGuard, new RoleGuard(['ADMIN']))
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 export class UserNoteAclController {
   constructor(
     private readonly aclService: UserNoteAclService,

--- a/src/modules/user-player-acl/user-player-acl.controller.ts
+++ b/src/modules/user-player-acl/user-player-acl.controller.ts
@@ -10,7 +10,7 @@ import {
   Query,
   UseGuards,
 } from '@nestjs/common';
-import { ApiCookieAuth, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { ApiSecurity, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { I18nLang, I18nService } from 'nestjs-i18n';
 
 import { ApiPaginatedResponse } from '../../common/api-response/api-paginated-response.decorator';
@@ -30,7 +30,7 @@ import { UserPlayerAclService } from './user-player-acl.service';
 @Controller('user-player-acl')
 @ApiTags('user player ACL')
 @UseGuards(AuthGuard, new RoleGuard(['ADMIN']))
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 export class UserPlayerAclController {
   constructor(
     private readonly aclService: UserPlayerAclService,

--- a/src/modules/user-report-acl/user-report-acl.controller.ts
+++ b/src/modules/user-report-acl/user-report-acl.controller.ts
@@ -10,7 +10,7 @@ import {
   Query,
   UseGuards,
 } from '@nestjs/common';
-import { ApiCookieAuth, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { ApiSecurity, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { I18nLang, I18nService } from 'nestjs-i18n';
 
 import { ApiPaginatedResponse } from '../../common/api-response/api-paginated-response.decorator';
@@ -30,7 +30,7 @@ import { UserReportAclService } from './user-report-acl.service';
 @Controller('user-report-acl')
 @ApiTags('user report ACL')
 @UseGuards(AuthGuard, new RoleGuard(['ADMIN']))
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 export class UserReportAclController {
   constructor(
     private readonly aclService: UserReportAclService,

--- a/src/modules/user-subscriptions/user-subscriptions.controller.ts
+++ b/src/modules/user-subscriptions/user-subscriptions.controller.ts
@@ -10,7 +10,7 @@ import {
   Query,
   UseGuards,
 } from '@nestjs/common';
-import { ApiCookieAuth, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { ApiSecurity, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { I18nLang, I18nService } from 'nestjs-i18n';
 
 import { ApiPaginatedResponse } from '../../common/api-response/api-paginated-response.decorator';
@@ -30,7 +30,7 @@ import { UserSubscriptionsService } from './user-subscriptions.service';
 @Controller('user-subscriptions')
 @ApiTags('user subscriptions')
 @UseGuards(AuthGuard, new RoleGuard(['ADMIN']))
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 export class UserSubscriptionsController {
   constructor(
     private readonly userSubscriptionsService: UserSubscriptionsService,

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -14,7 +14,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import {
   ApiBody,
   ApiConsumes,
-  ApiCookieAuth,
+  ApiSecurity,
   ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
@@ -37,7 +37,7 @@ import { UsersService } from './users.service';
 @Controller('users')
 @ApiTags('users')
 @UseGuards(AuthGuard, new RoleGuard(['ADMIN']))
-@ApiCookieAuth()
+@ApiSecurity('auth-token')
 export class UsersController {
   constructor(
     private readonly usersService: UsersService,


### PR DESCRIPTION
### Task Description

TL;DR only dev (swagger docs) stuff

dealt with this out of my own pain as I use insomnia quite often and it bothered me

- fixed swagger docs auth (changed from cookies that we dont use to x-auth-token header)
you can now actually test something in these docs
- improved qualitty of exporting docs json to insomnia(and probably anywhere else) by adding a insomnia button and declaring host(server) address and stuff point above

- as a bonus included vscode debug config for nestjs and fixed debug command that I always have to stash or avoid


