### PR TITLE
Fix/SCOUT-288-organization-subscriptions-cache

### DIFF
--- a/src/modules/organization-subscriptions/dto/update-organization-subscription.dto.ts
+++ b/src/modules/organization-subscriptions/dto/update-organization-subscription.dto.ts
@@ -1,7 +1,3 @@
-import { OmitType, PartialType } from '@nestjs/swagger';
-
 import { CreateOrganizationSubscriptionDto } from './create-organization-subscription.dto';
 
-export class UpdateOrganizationSubscriptionDto extends PartialType(
-  OmitType(CreateOrganizationSubscriptionDto, ['organizationId']),
-) {}
+export class UpdateOrganizationSubscriptionDto extends CreateOrganizationSubscriptionDto {}

--- a/src/modules/organization-subscriptions/dto/update-organization-subscription.dto.ts
+++ b/src/modules/organization-subscriptions/dto/update-organization-subscription.dto.ts
@@ -1,3 +1,7 @@
+import { OmitType, PartialType } from '@nestjs/swagger';
+
 import { CreateOrganizationSubscriptionDto } from './create-organization-subscription.dto';
 
-export class UpdateOrganizationSubscriptionDto extends CreateOrganizationSubscriptionDto {}
+export class UpdateOrganizationSubscriptionDto extends PartialType(
+  OmitType(CreateOrganizationSubscriptionDto, ['organizationId']),
+) {}

--- a/src/modules/organization-subscriptions/organization-subscriptions.service.ts
+++ b/src/modules/organization-subscriptions/organization-subscriptions.service.ts
@@ -133,15 +133,8 @@ export class OrganizationSubscriptionsService {
     id: string,
     updateOrganizationSubscriptionDto: UpdateOrganizationSubscriptionDto,
   ) {
-    const {
-      startDate,
-      endDate,
-      competitionIds,
-      competitionGroupIds,
-      organizationId,
-    } = updateOrganizationSubscriptionDto;
-
-    this.deleteFormattedFromCache(organizationId);
+    const { startDate, endDate, competitionIds, competitionGroupIds } =
+      updateOrganizationSubscriptionDto;
 
     const shouldUpdateCompetitions =
       competitionIds && competitionIds.length > 0;
@@ -162,32 +155,37 @@ export class OrganizationSubscriptionsService {
       );
     }
 
-    return this.prisma.organizationSubscription.update({
-      where: { id },
-      data: {
-        startDate: startDate ? new Date(startDate) : undefined,
-        endDate: endDate ? new Date(endDate) : undefined,
-        competitions: shouldUpdateCompetitions
-          ? {
-              createMany: {
-                data: competitionIds.map((id) => ({
-                  competitionId: id,
-                })),
-              },
-            }
-          : undefined,
-        competitionGroups: shouldUpdateCompetitionGroups
-          ? {
-              createMany: {
-                data: competitionGroupIds.map((id) => ({
-                  groupId: id,
-                })),
-              },
-            }
-          : undefined,
-      },
-      include,
-    });
+    const updatedSubsripiton =
+      await this.prisma.organizationSubscription.update({
+        where: { id },
+        data: {
+          startDate: startDate ? new Date(startDate) : undefined,
+          endDate: endDate ? new Date(endDate) : undefined,
+          competitions: shouldUpdateCompetitions
+            ? {
+                createMany: {
+                  data: competitionIds.map((id) => ({
+                    competitionId: id,
+                  })),
+                },
+              }
+            : undefined,
+          competitionGroups: shouldUpdateCompetitionGroups
+            ? {
+                createMany: {
+                  data: competitionGroupIds.map((id) => ({
+                    groupId: id,
+                  })),
+                },
+              }
+            : undefined,
+        },
+        include,
+      });
+
+    this.deleteFormattedFromCache(updatedSubsripiton.organizationId);
+
+    return updatedSubsripiton;
   }
 
   async getFormattedForSingleOrganization(

--- a/src/modules/organization-subscriptions/organization-subscriptions.service.ts
+++ b/src/modules/organization-subscriptions/organization-subscriptions.service.ts
@@ -155,7 +155,7 @@ export class OrganizationSubscriptionsService {
       );
     }
 
-    const updatedSubsripiton =
+    const updatedSubscription =
       await this.prisma.organizationSubscription.update({
         where: { id },
         data: {


### PR DESCRIPTION
### Task Description
[SCOUT-288](https://playmakerpro.atlassian.net/browse/SCOUT-288?atlOrigin=eyJpIjoiNDQxOWViMGI2NjUzNDdmNjk4Y2UxZjk4Mzc0YmQwMzMiLCJwIjoiaiJ9)

organization subscriptions
- fixed cache not updating when editing, deleting, add another subscription to the same organization
- included organizationId in updateDto

didn't get deep into how but frontend already sends organizationId without changes so that's good