### PR TITLE
fix displaying subscription with no comp groups

### DIFF
--- a/src/modules/user-subscriptions/user-subscriptions.service.ts
+++ b/src/modules/user-subscriptions/user-subscriptions.service.ts
@@ -81,8 +81,12 @@ export class UserSubscriptionsService {
 
     const where: Prisma.UserSubscriptionWhereInput = {
       userId,
-      competitions: { some: { competitionId: { in: competitionIds } } },
-      competitionGroups: { some: { groupId: { in: competitionGroupIds } } },
+      competitions: competitionIds
+        ? { some: { competitionId: { in: competitionIds } } }
+        : undefined,
+      competitionGroups: competitionGroupIds
+        ? { some: { groupId: { in: competitionGroupIds } } }
+        : undefined,
     };
 
     const subscriptions = await this.prisma.userSubscription.findMany({

--- a/src/modules/user-subscriptions/user-subscriptions.service.ts
+++ b/src/modules/user-subscriptions/user-subscriptions.service.ts
@@ -7,7 +7,11 @@ import {
   CachedFormattedSubscription,
   FormattedSubscription,
 } from '../../types/formatted-subscription';
-import { calculateSkip, formatPaginatedResponse } from '../../utils/helpers';
+import {
+  calculateSkip,
+  formatPaginatedResponse,
+  isIdsArrayFilterDefined,
+} from '../../utils/helpers';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateUserSubscriptionDto } from './dto/create-user-subscription.dto';
 import { FindAllUserSubscriptionsDto } from './dto/find-all-user-subscriptions.dto';
@@ -81,10 +85,10 @@ export class UserSubscriptionsService {
 
     const where: Prisma.UserSubscriptionWhereInput = {
       userId,
-      competitions: competitionIds
+      competitions: isIdsArrayFilterDefined(competitionIds)
         ? { some: { competitionId: { in: competitionIds } } }
         : undefined,
-      competitionGroups: competitionGroupIds
+      competitionGroups: isIdsArrayFilterDefined(competitionGroupIds)
         ? { some: { groupId: { in: competitionGroupIds } } }
         : undefined,
     };


### PR DESCRIPTION
### Task Description
[SCOUT-287](https://playmakerpro.atlassian.net/browse/SCOUT-287?atlOrigin=eyJpIjoiNDViMzE1NGE1MDQ1NDcxZGE2ZTQ4YjEzMDg3Y2E1MmEiLCJwIjoiaiJ9)

- fixed not displaying user subs without competition groups