### PR TITLE
[SCOUT-250] adjust filters

### DIFF
--- a/src/modules/notes/dto/find-all-notes.dto.ts
+++ b/src/modules/notes/dto/find-all-notes.dto.ts
@@ -93,6 +93,11 @@ export class FindAllNotesDto {
   @IsBoolean()
   @Transform(({ value }) => value === 'true')
   onlyLikedPlayers?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  @Transform(({ value }) => value === 'true')
+  onlyNullPlayers?: boolean;
 }
 
 export class GetNotesListDto extends PickType(FindAllNotesDto, ['matchIds']) {}

--- a/src/modules/notes/notes.service.ts
+++ b/src/modules/notes/notes.service.ts
@@ -276,12 +276,8 @@ export class NotesService {
                 : undefined,
             },
             {
-              OR: isIdsArrayFilterDefined(teamIds)
-                ? [
-                    { match: { homeTeam: { id: { in: teamIds } } } },
-                    { match: { awayTeam: { id: { in: teamIds } } } },
-                    { meta: { team: { id: { in: teamIds } } } },
-                  ]
+              meta: isIdsArrayFilterDefined(teamIds)
+                ? { team: { id: { in: teamIds } } }
                 : undefined,
             },
             {

--- a/src/modules/notes/notes.service.ts
+++ b/src/modules/notes/notes.service.ts
@@ -208,6 +208,7 @@ export class NotesService {
       userId: userIdFindParam,
       onlyLikedPlayers,
       onlyLikedTeams,
+      onlyNullPlayers,
     }: FindAllNotesDto,
     userId?: string,
     accessFilters?: Prisma.NoteWhereInput,
@@ -281,9 +282,22 @@ export class NotesService {
                 : undefined,
             },
             {
-              player: {
-                yearOfBirth: { gte: playerBornAfter, lte: playerBornBefore },
-              },
+              player: playerBornAfter
+                ? {
+                    yearOfBirth: {
+                      gte: playerBornAfter,
+                    },
+                  }
+                : undefined,
+            },
+            {
+              player: playerBornBefore
+                ? {
+                    yearOfBirth: {
+                      lte: playerBornBefore,
+                    },
+                  }
+                : undefined,
             },
             {
               player: onlyLikedPlayers
@@ -295,10 +309,13 @@ export class NotesService {
                 ? { team: { likes: { some: { userId } } } }
                 : undefined,
             },
+            { playerId: onlyNullPlayers ? null : undefined },
           ],
         },
       ],
     };
+
+    console.log(where);
 
     const notes = await this.prisma.note.findMany({
       where,

--- a/src/modules/reports/reports.service.ts
+++ b/src/modules/reports/reports.service.ts
@@ -350,12 +350,8 @@ export class ReportsService {
                 : undefined,
             },
             {
-              OR: isIdsArrayFilterDefined(teamIds)
-                ? [
-                    { match: { homeTeam: { id: { in: teamIds } } } },
-                    { match: { awayTeam: { id: { in: teamIds } } } },
-                    { meta: { team: { id: { in: teamIds } } } },
-                  ]
+              meta: isIdsArrayFilterDefined(teamIds)
+                ? { team: { id: { in: teamIds } } }
                 : undefined,
             },
             {

--- a/src/modules/reports/reports.service.ts
+++ b/src/modules/reports/reports.service.ts
@@ -355,9 +355,22 @@ export class ReportsService {
                 : undefined,
             },
             {
-              player: {
-                yearOfBirth: { gte: playerBornAfter, lte: playerBornBefore },
-              },
+              player: playerBornAfter
+                ? {
+                    yearOfBirth: {
+                      gte: playerBornAfter,
+                    },
+                  }
+                : undefined,
+            },
+            {
+              player: playerBornBefore
+                ? {
+                    yearOfBirth: {
+                      lte: playerBornBefore,
+                    },
+                  }
+                : undefined,
             },
             {
               player: onlyLikedPlayers


### PR DESCRIPTION
[SCOUT-250](https://playmakerpro.atlassian.net/browse/SCOUT-250)

### Task Description

- fixes the issue with filtering notes and reports by `teamIds` - querying for 

```
{ match: { homeTeam: { id: { in: teamIds } } } },
{ match: { awayTeam: { id: { in: teamIds } } } },
```

was causing a situation where following query params:

- `teamA`, `matchC`
- `teamB`, `matchC`

resulted with the same array of documents, with the assumption that `matchC -> teamA vs. teamB`

- fixes the issue with filtering notes and reports by player date of birth - using

```
player: {
    yearOfBirth: { gte: playerBornAfter, lte: playerBornBefore },
},
```

when `playerBornAfter` & `playerBornBefore` could be undefined caused unpredictable results

- adds `onlyNullPlayers` to `FindAllNotesDto` - flag for querying only notes with no player relation

### Additional Notes (optional)

<!-- Provide any additional notes: related PRs, screenshots, et al.). -->
