### PR TITLE
[SCOUT-283] add date constraint to players team include

### DIFF
--- a/src/modules/players/players.service.ts
+++ b/src/modules/players/players.service.ts
@@ -51,6 +51,7 @@ const include: Prisma.PlayerInclude = {
   primaryPosition: true,
   secondaryPositions: { include: { position: true } },
   teams: {
+    where: { endDate: null },
     include: {
       team: true,
     },
@@ -70,6 +71,7 @@ const singleInclude = Prisma.validator<Prisma.PlayerInclude>()({
   secondaryPositions: { include: { position: true } },
   author: true,
   teams: {
+    where: { endDate: null },
     include: {
       team: {
         include: {

--- a/src/modules/reports/reports.service.ts
+++ b/src/modules/reports/reports.service.ts
@@ -49,7 +49,7 @@ const include: Prisma.ReportInclude = {
     include: {
       country: true,
       primaryPosition: true,
-      teams: { include: { team: true } },
+      teams: { include: { team: true }, where: { endDate: null } },
     },
   },
   match: { include: { homeTeam: true, awayTeam: true } },
@@ -68,7 +68,7 @@ const singleInclude = Prisma.validator<Prisma.ReportInclude>()({
     include: {
       country: true,
       primaryPosition: true,
-      teams: { include: { team: true } },
+      teams: { include: { team: true }, where: { endDate: null } },
     },
   },
   match: { include: { homeTeam: true, awayTeam: true, competition: true } },
@@ -89,7 +89,7 @@ const listInclude: Prisma.ReportInclude = {
     include: {
       country: true,
       primaryPosition: true,
-      teams: { include: { team: true } },
+      teams: { include: { team: true }, where: { endDate: null } },
     },
   },
   author: true,


### PR DESCRIPTION
[SCOUT-283](https://playmakerpro.atlassian.net/browse/SCOUT-283)

### Task Description

Add `endDate` constraint to players team include. Up until now, we were including ALL `teamAffiliation` relations on players and displayed the first item from returned array as a current team on the frontend. This is wrong since the player can be currently unemployed, hence he doesn't have any `teamAffiliation` relation with `endDate === null`. This is now handled properly.

### Additional Notes (optional)

<!-- Provide any additional notes: related PRs, screenshots, et al.). -->
