### PR TITLE
fix: optional chaining for meta fields

### DIFF
--- a/src/modules/notes/notes.service.ts
+++ b/src/modules/notes/notes.service.ts
@@ -114,9 +114,9 @@ export class NotesService {
       metaPositionId = positionPlayedId || player.primaryPositionId;
       metaTeamId = teamId || player.teams[0]?.teamId;
       metaCompetitionId =
-        competitionId || player.teams[0]?.team.competitions[0].competitionId;
+        competitionId || player.teams[0]?.team.competitions[0]?.competitionId;
       metaCompetitionGroupId =
-        competitionGroupId || player.teams[0]?.team.competitions[0].groupId;
+        competitionGroupId || player.teams[0]?.team.competitions[0]?.groupId;
     }
 
     return this.prisma.note.create({
@@ -152,6 +152,7 @@ export class NotesService {
 
     const instances = result.data.map((item) => {
       const instance = new CreateNoteDto();
+
       instance.id = item.id?.toString();
       instance.shirtNo = item.shirtNo;
       instance.description = item.description;
@@ -421,7 +422,7 @@ export class NotesService {
       const metaCompetitionId =
         competitionId || player.teams[0].team.competitions[0]?.competitionId;
       const metaCompetitionGroupId =
-        competitionGroupId || player.teams[0]?.team.competitions[0].groupId;
+        competitionGroupId || player.teams[0]?.team.competitions[0]?.groupId;
 
       await this.prisma.noteMeta.create({
         data: {

--- a/src/modules/reports/reports.service.ts
+++ b/src/modules/reports/reports.service.ts
@@ -174,9 +174,9 @@ export class ReportsService {
     const metaPositionId = positionPlayedId || player.primaryPositionId;
     const metaTeamId = teamId || player.teams[0]?.teamId;
     const metaCompetitionId =
-      competitionId || player.teams[0]?.team.competitions[0].competitionId;
+      competitionId || player.teams[0]?.team.competitions[0]?.competitionId;
     const metaCompetitionGroupId =
-      competitionGroupId || player.teams[0]?.team.competitions[0].groupId;
+      competitionGroupId || player.teams[0]?.team.competitions[0]?.groupId;
 
     const areSkillAssessmentsIncluded =
       skillAssessments && skillAssessments.length > 0;
@@ -477,9 +477,9 @@ export class ReportsService {
       metaPositionId = positionPlayedId || player.primaryPositionId;
       metaTeamId = teamId || player.teams[0]?.teamId;
       metaCompetitionId =
-        competitionId || player.teams[0]?.team.competitions[0].competitionId;
+        competitionId || player.teams[0]?.team.competitions[0]?.competitionId;
       metaCompetitionGroupId =
-        competitionGroupId || player.teams[0]?.team.competitions[0].groupId;
+        competitionGroupId || player.teams[0]?.team.competitions[0]?.groupId;
 
       await this.prisma.reportMeta.update({
         where: { reportId: id },


### PR DESCRIPTION
### Task Description

Adds optional chaining in `meta` relations calculations - fixes the error in the situation where player has the team but the team doesn't have any competitions or competition groups assigned to it. 

### Additional Notes (optional)

<!-- Provide any additional notes: related PRs, screenshots, et al.). -->
