### PR TITLE
implement percentageRatingRanges

### DIFF
--- a/src/modules/notes/dto/find-all-notes.dto.ts
+++ b/src/modules/notes/dto/find-all-notes.dto.ts
@@ -11,7 +11,7 @@ import {
   Min,
 } from 'class-validator';
 
-import { ObservationTypeEnum } from '../../../types/common';
+import { ObservationTypeEnum, RatingRangesEnum } from '../../../types/common';
 
 export class FindAllNotesDto {
   @IsOptional()
@@ -63,6 +63,17 @@ export class FindAllNotesDto {
   @Min(0)
   @Max(100)
   percentageRatingRangeEnd?: number;
+
+  @IsOptional()
+  @Transform(({ value }) => (typeof value === 'string' ? [value] : value))
+  @IsArray()
+  @IsEnum(RatingRangesEnum, {
+    message: `Percentage rating ranges must be a valid enum value. Available values: ${Object.keys(
+      RatingRangesEnum,
+    ).join(', ')}`,
+    each: true,
+  })
+  percentageRatingRanges?: RatingRangesEnum[];
 
   @IsOptional()
   @Transform(({ value }) => parseInt(value))

--- a/src/modules/notes/notes.service.ts
+++ b/src/modules/notes/notes.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@nestjs/common';
 import { Note, Prisma } from '@prisma/client';
 import Redis from 'ioredis';
 
-import { REDIS_TTL } from '../../utils/constants';
+import { percentageRatingRanges, REDIS_TTL } from '../../utils/constants';
 import { parseCsv, validateInstances } from '../../utils/csv-helpers';
 import {
   calculatePercentageRating,
@@ -211,6 +211,7 @@ export class NotesService {
       onlyLikedPlayers,
       onlyLikedTeams,
       onlyWithoutPlayers,
+      percentageRatingRanges: percentageRatingRangesFilter,
     }: FindAllNotesDto,
     userId?: string,
     accessFilters?: Prisma.NoteWhereInput,
@@ -313,6 +314,14 @@ export class NotesService {
                 : undefined,
             },
             { playerId: onlyWithoutPlayers ? null : undefined },
+            {
+              OR: percentageRatingRangesFilter?.map((range) => ({
+                percentageRating: {
+                  gte: percentageRatingRanges[range][0],
+                  lte: percentageRatingRanges[range][1],
+                },
+              })),
+            },
           ],
         },
       ],

--- a/src/modules/reports/dto/find-all-reports.dto.ts
+++ b/src/modules/reports/dto/find-all-reports.dto.ts
@@ -10,7 +10,7 @@ import {
   Min,
 } from 'class-validator';
 
-import { ObservationTypeEnum } from '../../../types/common';
+import { ObservationTypeEnum, RatingRangesEnum } from '../../../types/common';
 
 export class FindAllReportsDto {
   @IsOptional()
@@ -62,6 +62,17 @@ export class FindAllReportsDto {
   @Min(0)
   @Max(100)
   percentageRatingRangeEnd?: number;
+
+  @IsOptional()
+  @Transform(({ value }) => (typeof value === 'string' ? [value] : value))
+  @IsArray()
+  @IsEnum(RatingRangesEnum, {
+    message: `Percentage rating ranges must be a valid enum value. Available values: ${Object.keys(
+      RatingRangesEnum,
+    ).join(', ')}`,
+    each: true,
+  })
+  percentageRatingRanges?: RatingRangesEnum[];
 
   @IsOptional()
   @Transform(({ value }) => parseInt(value))

--- a/src/modules/reports/reports.service.ts
+++ b/src/modules/reports/reports.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@nestjs/common';
 import { Prisma, Report, ReportTemplate } from '@prisma/client';
 import Redis from 'ioredis';
 
-import { REDIS_TTL } from '../../utils/constants';
+import { percentageRatingRanges, REDIS_TTL } from '../../utils/constants';
 import { parseCsv, validateInstances } from '../../utils/csv-helpers';
 import {
   calculateAvg,
@@ -306,6 +306,7 @@ export class ReportsService {
       observationType,
       onlyLikedPlayers,
       onlyLikedTeams,
+      percentageRatingRanges: percentageRatingRangesFilter,
     } = query;
 
     return {
@@ -383,6 +384,14 @@ export class ReportsService {
               meta: onlyLikedTeams
                 ? { team: { likes: { some: { userId } } } }
                 : undefined,
+            },
+            {
+              OR: percentageRatingRangesFilter?.map((range) => ({
+                percentageRating: {
+                  gte: percentageRatingRanges[range][0],
+                  lte: percentageRatingRanges[range][1],
+                },
+              })),
             },
           ],
         },

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -8,3 +8,11 @@ export enum ObservationTypeEnum {
   LIVE = 'LIVE',
   VIDEO = 'VIDEO',
 }
+
+export enum RatingRangesEnum {
+  ALL = 'ALL',
+  NEGATIVE_SELECTION = 'NEGATIVE_SELECTION',
+  NO_DECISION = 'NO_DECISION',
+  TO_OBSERVE = 'TO_OBSERVE',
+  POSITIVE_SELECTION = 'POSITIVE_SELECTION',
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -20,3 +20,11 @@ export const playmakerRoles: UserRole[] = [
   'PLAYMAKER_SCOUT',
   'PLAYMAKER_SCOUT_MANAGER',
 ];
+
+export const percentageRatingRanges = {
+  ALL: [undefined, undefined],
+  NEGATIVE_SELECTION: [0, 25],
+  NO_DECISION: [26, 50],
+  TO_OBSERVE: [51, 75],
+  POSITIVE_SELECTION: [76, 100],
+} as const;


### PR DESCRIPTION
### Task Description
[SCOUT-369](https://playmakerpro.atlassian.net/browse/SCOUT-369?atlOrigin=eyJpIjoiOTg1MjgwZGY5ODFjNDc2NTkzMjA3NjkxODAwM2ZlNDAiLCJwIjoiaiJ9)

- added filter that allows multi rating ranges filtering in notes&reports

should the name of the filter stay like that or maybe change it to just `ratingRanges` ?

tl;dr moved our frontend whacky mapping filter state stuff to the backend